### PR TITLE
Add workaround for https://github.com/taf2/curb/issues/397

### DIFF
--- a/lib/faraday/adapter/curb.rb
+++ b/lib/faraday/adapter/curb.rb
@@ -52,8 +52,8 @@ module Faraday
 
       def configure_timeout(client, env)
         req = env[:request]
-        client.timeout          = req[:timeout] if req[:timeout]
-        client.connect_timeout  = req[:open_timeout] if req[:open_timeout]
+        client.timeout_ms          = (req[:timeout]*1000).to_i if req[:timeout]
+        client.connect_timeout_ms  = (req[:open_timeout]*1000).to_i if req[:open_timeout]
       end
 
       # Borrowed from Patron:


### PR DESCRIPTION
Although Curb added support for floating point values in `timeout` in https://github.com/taf2/curb/pull/361/files, the same problem still persists for `connect_timeout`.

This PR works around the issue by using the millisecond options instead.